### PR TITLE
添加 .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+sass_binary_site=https://npm.taobao.org/mirrors/node-sass/
+electron_mirror=https://npm.taobao.org/mirrors/electron/


### PR DESCRIPTION
由于网络原因, 使用 `npm.taobao.org` 可以大幅提高 安装`electron` 和 `node-sass` 的速度